### PR TITLE
add female indweight to DHS individuals; adjust male weight for sample proportion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi.utils
 Title: Utility Functions For Naomi Datasets
-Version: 0.0.10
+Version: 0.0.11
 Authors@R: 
     person(given = "Jeffrey",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# naomi.utils 0.0.11
+
+* Extract individual survey weights for all respondents and adjust male survey weights
+  such that pooled male/female data are weighted representative of the full adult 
+  population (https://userforum.dhsprogram.com/index.php?t=msg&th=6387&goto=13190&#msg_13190).
+* Patch [`create_surveys_dhs()`] to enable extraction of surveys from more than one country in
+  one function call (change `== iso3` to `%in% iso3`).
+
+
 # naomi.utils 0.0.10
 
 * Patch `assert_pop_data_check()` and `assert_area_id_check()` to specify `dplyr::setdiff()` (instead of base `generics::setdiff()`.


### PR DESCRIPTION
This PR:

* Adds `indweight` to the female individuals extract.
* Scales the male weights to account for reduced sampling fraction, such that combining female and male `indweight` produces population representative estimates.
  * Uses the method described by Tom Pullum on [DHS User Forum](https://userforum.dhsprogram.com/index.php?t=msg&th=6387&goto=13190&#msg_13190).
* Update `create_surveys_dhs()` to enable multiple `iso3` in the same function call.

