### PR TITLE
Revert "Revert "Allow specification of cores for parallel computation""

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi.utils
 Title: Utility Functions For Naomi Datasets
-Version: 0.1.11
+Version: 0.1.2
 Authors@R: 
     person(given = "Jeffrey",
            family = "Eaton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi.utils
 Title: Utility Functions For Naomi Datasets
-Version: 0.1.1
+Version: 0.1.11
 Authors@R: 
     person(given = "Jeffrey",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# naomi.utils 0.1.11
+
+* Allow optional specification of cores for parallel computation, which may 
+help with memory problems when too many cores are used. 
+
 # naomi.utils 0.1.1
 
 * Update extracted DHS sexual behaviour variables

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# naomi.utils 0.1.11
+# naomi.utils 0.1.2
 
 * Allow optional specification of cores for parallel computation, which may 
 help with memory problems when too many cores are used. 


### PR DESCRIPTION
Allow for user specification of number of cores used for parallel computation. 

This commit arose due to running out of memory when running `calc_survey_indicators` in parallel with 8 cores. Using less cores mitigates the danger of this occurring.