### PR TITLE
mrc-3542: Update dataset migration script for 2023 datasets

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,16 @@
+FROM rocker/r-ver:4
+
+COPY bin /usr/local/bin/
+
+RUN apt-get update && apt-get -y install --no-install-recommends \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN install_packages --repo "https://mrc-ide.r-universe.dev" \
+        ckanr \
+        docopt \
+        jsonlite
+
+COPY copy_adr_data.R /usr/local/bin/
+
+ENTRYPOINT ["copy_adr_data.R"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,44 @@
+## Scripts
+
+This dir contains naomi related scripts including:
+
+* copy_adr_data.R - copies datasets from 1 ADR year into another, we have used this in 2021 and 2022 to create intial datasets for country teams
+
+### copy ADR datasets
+
+To run this we need an API key, it can sometimes be useful for someone with more privileges to run the script such as Ian or someone from Fjelltopp to avoid issues with dataset access. For this there is a docker container to make running easier.
+
+#### Build image 
+
+From `scripts` dir
+```
+docker build -t mrcide/adr-copy:latest .
+```
+
+#### Push image
+
+```
+docker push mrcide/adr-copy:latest
+```
+
+#### Run script
+
+Show help
+```
+docker run --rm mrcide/adr-copy:latest -h
+```
+
+Dry run, key is your ADR API key
+```
+docker run --rm mrcide/adr-copy:latest --dry-run --key=<key>
+```
+
+Run on dev
+```
+docker run --rm mrcide/adr-copy:latest --key=<key>
+```
+
+Run on prod
+```
+docker run --rm mrcide/adr-copy:latest --site=prod --key=<key>
+```

--- a/scripts/bin/install_packages
+++ b/scripts/bin/install_packages
@@ -1,0 +1,15 @@
+#!/usr/bin/env Rscript
+'Usage:
+install_packages [--repo=REPO...] <package>...' -> usage
+opts <- docopt::docopt(usage)
+
+repos <- opts$repo
+packages <- opts$package
+
+options(repos = c(repos, getOption("repos")))
+install.packages(packages)
+
+msg <- setdiff(packages, .packages(TRUE))
+if (length(msg) > 0L) {
+  stop("Failed to install: ", paste(msg, collapse = ", "))
+}

--- a/scripts/copy_adr_data.R
+++ b/scripts/copy_adr_data.R
@@ -115,7 +115,7 @@ for (package in packages_copy) {
     tryCatch({
       new_package <- NULL
       new_package <- ckanr::package_create(
-        type = dest, owner_org = "naomi-development-team",
+        type = dest, owner_org = package[["organization"]][["name"]], 
         extras = list("geo-location" = package[["geo-location"]],
                       type_name = dest_name,
                       maintainer_email = "naomi-support@unaids.org",

--- a/scripts/copy_adr_data.R
+++ b/scripts/copy_adr_data.R
@@ -85,7 +85,6 @@ for (country in multiple) {
                   country, src))
 }
 countries_to_copy <- countries_src[!(countries_src %in% multiple)]
-countries_to_copy <- c("Cameroon", "Mali")
 
 packages_keep <- vapply(packages_src$results, function(package) {
   package[["geo-location"]] %in% countries_to_copy
@@ -153,12 +152,24 @@ for (package in packages_copy) {
     upload <- TRUE
     tryCatch({
       ckanr::ckan_fetch(details$url, store = "disk", path = path)
-      out <- readLines(path, n = 2, skipNul = TRUE)
-      ## If you do not have access to download the resource CKAN returns
-      ## you some HTML login page, if we get this then we want to error
-      if (out[1] == "<!DOCTYPE html>" || out[2] == "<!DOCTYPE html>") {
-        upload <- FALSE
-        stop("Your account does not have access to resource")
+      if (resource == "inputs-unaids-geographic") {
+        out <- readLines(path, n = 1, skipNul = TRUE)
+        ## If you do not have access to download the resource CKAN returns
+        ## you some HTML login page, if we get this then we want to error.
+        ## Make sure this is a JSON file
+        if (!startsWith(out[1], "{")) {
+          upload <- FALSE
+          stop("Your account does not have access to resource")
+        }
+      } else {
+        out <- readLines(path, n = 2, skipNul = TRUE)
+        ## If you do not have access to download the resource CKAN returns
+        ## you some HTML login page, if we get this then we want to error.
+        ## Make sure the csv does not contain HTML tags
+        if (out[1] == "<!DOCTYPE html>" || out[2] == "<!DOCTYPE html>") {
+          upload <- FALSE
+          stop("Your account does not have access to resource")
+        }
       }
       ## Also can return a HTML Gateway Time-out page if issue hitting endpoint
       ## if this is the case then error


### PR DESCRIPTION
This script will
* Copy input data from 2022 datasets into new 2023 datasets 
* Add empty columns `anc_known_neg` and `births_facility` for ANC data
* Create a release on the new dataset

I've run this on dev system for Cameroon and Mali and it looks good there. There are a couple of questions for UNAIDS or other
* Who should the maintainer be? At the moment it sets it as us when the package is created. Jonathan asked us to raise this as he thinks countries aren't really using the field as intended
* Cameroon is failing validation for uploaded files - I will ask ADR guys about this in the meeting tomorrow
   * population - I don't have permission to access this in 2022 dataset, meaning it downloads some page HTML and is malformed. ~~This won't be an error if we run with Rachel's key~~ this is not true, I have added some specific handling for this to not try and upload if the key does not have access
   * survey - this is complaining about "CMR" area_id missing from location hierarchy, I'm not sure why as it is available
   * ANC - this is erroring because "CMR_3_89" is not in area_id but again that does exist in area hierarchy. I am not sure what is going on
   * ART - same as ANC