### PR TITLE
mrc-3711: Update data migrations script to copy data from a release instead of current

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,27 +1,28 @@
-## Scripts
+# Scripts
 
 This dir contains naomi related scripts including:
 
 * copy_adr_data.R - copies datasets from 1 ADR year into another, we have used this in 2021 and 2022 to create intial datasets for country teams
+* remove_2023_datasets.R - Removes all 2023 datasets from ADR
 
-### copy ADR datasets
+## copy ADR datasets
 
 To run this we need an API key, it can sometimes be useful for someone with more privileges to run the script such as Ian or someone from Fjelltopp to avoid issues with dataset access. For this there is a docker container to make running easier.
 
-#### Build image 
+### Build image
 
 From `scripts` dir
 ```
 docker build -t mrcide/adr-copy:latest .
 ```
 
-#### Push image
+### Push image
 
 ```
 docker push mrcide/adr-copy:latest
 ```
 
-#### Run script
+### Run script
 
 Show help
 ```
@@ -41,4 +42,41 @@ docker run --rm mrcide/adr-copy:latest --key=<key>
 Run on prod
 ```
 docker run --rm mrcide/adr-copy:latest --site=prod --key=<key>
+```
+
+## Remove ADR datasets
+
+### Build image
+
+From `scripts` dir
+```
+docker build -t mrcide/remove-datasets:latest -f remove.Dockerfile .
+```
+
+### Push image
+
+```
+docker push mrcide/remove-datasets:latest
+```
+
+### Run script
+
+Show help
+```
+docker run --rm mrcide/remove-datasets:latest -h
+```
+
+Dry run, key is your ADR API key
+```
+docker run --rm mrcide/remove-datasets:latest --dry-run --key=<key>
+```
+
+Run on dev
+```
+docker run --rm mrcide/remove-datasets:latest --key=<key>
+```
+
+Run on prod
+```
+docker run --rm mrcide/remove-datasets:latest --site=prod --key=<key>
 ```

--- a/scripts/copy_adr_data.R
+++ b/scripts/copy_adr_data.R
@@ -103,9 +103,9 @@ get_release <- function(package, release_name) {
       ),
       release_name, package$id, package$name
     ))
+    release_id <- releases[[1]]$id
   }
-  release_id <- releases[[1]]$
-    package_show(package$id, release_id)
+  package_show(package$id, release_id)
 }
 
 packages_src <- ckanr::package_search(

--- a/scripts/copy_adr_data.R
+++ b/scripts/copy_adr_data.R
@@ -117,14 +117,14 @@ releases <- releases[!is.null(releases)]
 ## or avenir orgs as these are usually duplicates of country data
 orgs_to_ignore <- c("fjelltopp", "avenir-health", "imperial-college-london",
                     "naomi-development-team", "unaids", "project-balance")
-orgs <- vapply(packages_src$results,
+orgs <- vapply(releases$results,
                function(result) {
                  result[["organization"]][["name"]]
                }, character(1))
-packages_src$results <- packages_src$results[!(orgs %in% orgs_to_ignore)]
+releases$results <- releases$results[!(orgs %in% orgs_to_ignore)]
 
 ## Only create new packages for countries which don't already exist
-countries_src <- vapply(packages_src$results, "[[", character(1),
+countries_src <- vapply(releases$results, "[[", character(1),
                         "geo-location")
 countries_dest <- vapply(packages_dest$results, "[[", character(1),
                          "geo-location")
@@ -139,10 +139,10 @@ for (country in multiple) {
 }
 countries_to_copy <- countries_src[!(countries_src %in% multiple)]
 
-packages_keep <- vapply(packages_src$results, function(package) {
+packages_keep <- vapply(releases$results, function(package) {
   package[["geo-location"]] %in% countries_to_copy
 }, logical(1))
-packages_copy <- packages_src$results[packages_keep]
+packages_copy <- releases$results[packages_keep]
 
 upload_package <- function(package_id, package_name, path, resource_type) {
   ckanr::resource_create(

--- a/scripts/copy_adr_data.R
+++ b/scripts/copy_adr_data.R
@@ -21,7 +21,7 @@ dry_run <- args[["dry_run"]]
 key <- args[["key"]]
 site <- args[["site"]]
 if (site == "prod") {
-  url <-  "https://adr.unaids.org/"
+  url <- "https://adr.unaids.org/"
 } else if (site == "dev") {
   url <- "https://dev.adr.fjelltopp.org/"
 } else {
@@ -41,49 +41,119 @@ resources <- c("inputs-unaids-geographic", "inputs-unaids-anc",
 
 ## No built in way to send custom commands to CKAN so do a gross hack
 ckan_create_release <- function(id) {
-  res <- ckanr:::ckan_POST(url = ckanr::get_default_url(),
-                    method = "dataset_version_create",
-                    body = jsonlite::toJSON(list(
-                      dataset_id = id,
-                      name = "2022 data transfer",
-                      notes = paste0("Data automatically transferred from ",
-                                     "2022 dataset. Added blank columns to ART",
-                                     " data for new indicators.")
-                    ), auto_unbox = TRUE),
-                    key = ckanr::get_default_key(),
-                    encode = "json",
-                    headers = ckanr:::ctj())
+  res <- ckanr:::ckan_POST(
+    url = ckanr::get_default_url(),
+    method = "dataset_version_create",
+    body = jsonlite::toJSON(list(
+      dataset_id = id,
+      name = "2022 data transfer",
+      notes = paste0(
+        "Data automatically transferred from ",
+        "2022 dataset. Added blank columns to ART",
+        " data for new indicators."
+      )
+    ), auto_unbox = TRUE),
+    key = ckanr::get_default_key(),
+    encode = "json",
+    headers = ckanr:::ctj()
+  )
   ckanr:::jsl(res)
 }
 
-packages_src <- ckanr::package_search(q = sprintf("type:%s", src),
-                                       rows = 1000)
-packages_dest <- ckanr::package_search(q = sprintf("type:%s", dest),
-                                       rows = 1000)
+list_releases <- function(dataset_id) {
+  res <- ckanr:::ckan_GET(
+    url = ckanr::get_default_url(),
+    method = "dataset_version_list",
+    query = list(dataset_id = dataset_id),
+    key = ckanr::get_default_key(),
+    headers = ckanr:::ctj()
+  )
+  ckanr:::jsl(res)
+}
+
+package_show <- function(dataset_id, release_id) {
+  res <- ckanr:::ckan_GET(
+    url = ckanr::get_default_url(),
+    method = "package_show",
+    query = list(id = dataset_id, release = release_id),
+    key = ckanr::get_default_key(),
+    headers = ckanr:::ctj()
+  )
+  ckanr:::jsl(res)
+}
+
+get_release <- function(package, release_name) {
+  releases <- list_releases(package$id)
+  if (length(releases) == 0) {
+    message(sprintf("No release found for %s - skipping", package$name))
+    return(NULL)
+  }
+  release_id <- NULL
+  for (rel in releases) {
+    if (rel$name == release_name) {
+      release_id <- rel$id
+      break
+    }
+  }
+  if (is.null(release_id)) {
+    message(sprintf(
+      paste0(
+        "Release %s not found in package %s with name %s, ",
+        "falling back to most recent release"
+      ),
+      release_name, package$id, package$name
+    ))
+  }
+  release_id <- releases[[1]]$
+    package_show(package$id, release_id)
+}
+
+packages_src <- ckanr::package_search(
+  q = sprintf("type:%s", src),
+  rows = 1000
+)
+packages_dest <- ckanr::package_search(
+  q = sprintf("type:%s", dest),
+  rows = 1000
+)
+
+## Get named release for package
+releases <- lapply(packages_src$results, get_release, "naomi_final_2022")
+releases <- releases[!is.null(releases)]
 
 ## Don't migrate data for Fjeltopp, Naomi development team, Imperial, unaids
 ## or avenir orgs as these are usually duplicates of country data
-orgs_to_ignore <- c("fjelltopp", "avenir-health", "imperial-college-london",
-                    "naomi-development-team", "unaids", "project-balance")
-orgs <- vapply(packages_src$results,
-               function(result) {
-                 result[["organization"]][["name"]]
-               }, character(1))
-packages_src$results <- packages_src$results[!(orgs %in% orgs_to_ignore)]
+orgs_to_ignore <- c(
+  "fjelltopp", "avenir-health", "imperial-college-london",
+  "naomi-development-team", "unaids", "project-balance"
+)
+orgs <- vapply(
+  releases$results,
+  function(result) {
+    result[["organization"]][["name"]]
+  }, character(1)
+)
+releases$results <- releases$results[!(orgs %in% orgs_to_ignore)]
 
 ## Only create new packages for countries which don't already exist
-countries_src <- vapply(packages_src$results, "[[", character(1),
-                        "geo-location")
-countries_dest <- vapply(packages_dest$results, "[[", character(1),
-                         "geo-location")
+countries_src <- vapply(
+  releases$results, "[[", character(1),
+  "geo-location"
+)
+countries_dest <- vapply(
+  packages_dest$results, "[[", character(1),
+  "geo-location"
+)
 countries_keep <- !(countries_src %in% countries_dest)
 countries_src <- countries_src[countries_keep]
 
 ## If more than 1 dataset for a country - don't do anything report out
 multiple <- names(table(countries_src))[table(countries_src) > 1]
 for (country in multiple) {
-  message(sprintf("%s has more than 1 %s dataset, don't know how to migrate",
-                  country, src))
+  message(sprintf(
+    "%s has more than 1 %s dataset, don't know how to migrate",
+    country, src
+  ))
 }
 countries_to_copy <- countries_src[!(countries_src %in% multiple)]
 
@@ -98,9 +168,13 @@ upload_package <- function(package_id, package_name, path, resource_type) {
     name = package_name,
     upload = path,
     extras = list(
-      restricted = paste0('{"allowed_organizations": "unaids", ',
-                          '"allowed_users": "", "level": "restricted"}'),
-      resource_type = resource_type))
+      restricted = paste0(
+        '{"allowed_organizations": "unaids", ',
+        '"allowed_users": "", "level": "restricted"}'
+      ),
+      resource_type = resource_type
+    )
+  )
 }
 
 ## For each country, download 2021 resources

--- a/scripts/copy_adr_data.R
+++ b/scripts/copy_adr_data.R
@@ -88,6 +88,8 @@ get_release <- function(package, release_name) {
   for (rel in releases) {
     if (rel$name == release_name) {
       release_id <- rel$id
+      message(sprintf("Found release %s for package %s",
+                      release_name, package$name))
       break
     }
   }

--- a/scripts/remove.Dockerfile
+++ b/scripts/remove.Dockerfile
@@ -1,0 +1,15 @@
+FROM rocker/r-ver:4
+
+COPY bin /usr/local/bin/
+
+RUN apt-get update && apt-get -y install --no-install-recommends \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN install_packages --repo "https://mrc-ide.r-universe.dev" \
+        ckanr \
+        docopt
+
+COPY remove_2023_datasets.R /usr/local/bin/
+
+ENTRYPOINT ["remove_2023_datasets.R"]

--- a/scripts/remove_2023_datasets.R
+++ b/scripts/remove_2023_datasets.R
@@ -1,0 +1,68 @@
+#! /usr/bin/env Rscript
+"Delete 2023 ADR datasets. We need to do this because we want to
+  retrun the data copy script copying over data from a release
+  instead of the current version of the data.
+
+Usage:
+    remove_2023_datasets.R  [--dry-run] [--site=<site>] --key=<key>
+    remove_2023_datasets.R -h | --help
+
+Options
+    --dry-run     Run in dry-run mode.
+    --site=<site> ADR site to use dev or prod [default: dev].
+    --key=<key>   ADR auth key.
+" -> doc
+
+args <- docopt::docopt(doc)
+dry_run <- args[["dry_run"]]
+key <- args[["key"]]
+site <- args[["site"]]
+if (site == "prod") {
+  url <- "https://adr.unaids.org/"
+} else if (site == "dev") {
+  url <- "https://dev.adr.fjelltopp.org/"
+} else {
+  stop("Site must be prod or dev")
+}
+message("Deleting datasets from ", url)
+
+ckanr::ckanr_setup(url = url, key = key)
+type <- "country-estimates-23"
+
+datasets <- ckanr::package_search(q = sprintf("type:%s", type),
+                                  rows = 1000)
+
+for (dataset in datasets$results) {
+  message("Removing dataset ", dataset$name)
+  attempt <- 0
+  complete <- FALSE
+  while (!complete && attempt < 5) {
+    attempt <- attempt + 1
+    tryCatch({
+      if (!dry_run) {
+        ckanr::package_delete(dataset$id)
+      }
+      message("Succesfully removed ", dataset$name)
+      complete <- TRUE
+    },
+    error = function(e) {
+      if (grepl("Authorization Error", e$message)) {
+        message(e$message)
+        attempt <<- 10 ## Exit immediately
+      } else {
+        ## If we've failed to delete it might be because ADR is
+        ## dealing with too many requests. Wait with incremental back off
+        wait <- 30 * attempt
+        message(sprintf(paste0("Failed to remove dataset %s: attempt %s. ",
+                               "Trying again in %s seconds."),
+                dataset$name, attempt, wait))
+        Sys.sleep(wait)
+      }
+    })
+  }
+  if (!complete) {
+    message(sprintf(
+      "Failed to remove %s, either no permission or ADR overloaded with requests",
+      dataset$name))
+  }
+}


### PR DESCRIPTION
This PR will
* Add a script to remove 2023 datasets from ADR
* Update the copy script to
   * Find releases for the listed packages
   * If there is a release named `naomi_final_2022` this will be used as the source of data
   * If not it will use the latest release
   * If there are no releases it will report that and skip that country, we will have to deal with these manually (if there are any)