### PR TITLE
patch logic in gather_areas()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi.utils
 Title: Utility Functions For Naomi Datasets
-Version: 0.0.13
+Version: 0.0.14
 Authors@R: 
     person(given = "Jeffrey",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi.utils 0.0.14
+
+* Patch logic error in `gather_areas()`.
+
 # naomi.utils 0.0.13
 
 * Copy `get_age_groups()` from naomi package. 

--- a/R/utils_areas.R
+++ b/R/utils_areas.R
@@ -269,7 +269,7 @@ gather_areas <- function(x) {
 
   for(i in 1:6) {
 
-    if(exists(paste0("id", i), x) && !is.na(x[[paste0("id", i)]])) {
+    if(exists(paste0("id", i), x) && !all(is.na(x[[paste0("id", i)]]))) {
 
       new_level <- x %>%
           dplyr::rename(area_id = paste0("id", i),


### PR DESCRIPTION
Small logic fix in `gather_areas()` I found when updating some Malawi scripts to orderly2.

I'm not quite sure why this hasn't cropped up before. I think it might be related to something that was enforced more strictly in a recent R version upgrade.