### PR TITLE
Update survey scripts to account for sf() updates and R 4.5.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi.utils
 Title: Utility Functions For Naomi Datasets
-Version: 0.0.17
+Version: 0.0.18
 Authors@R: 
     person(given = "Jeffrey",
            family = "Eaton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi.utils
 Title: Utility Functions For Naomi Datasets
-Version: 0.0.18
+Version: 0.0.17
 Authors@R: 
     person(given = "Jeffrey",
            family = "Eaton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Imports:
     raster,
     rdhs (>= 0.7.1),
     sf,
-    spud,
     survey,
     tidyr
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi.utils
 Title: Utility Functions For Naomi Datasets
-Version: 0.0.16
+Version: 0.0.17
 Authors@R: 
     person(given = "Jeffrey",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # naomi.utils 0.0.17
 
 * Remove `spud` dependency as package is deprecated 
+* Update debug functions in line with updated data structure in fit object 
+downloaded from download_debug()
 * Fix GE dataset parsing broken by R/sf upgrade
   * After upgrading to R 4.5.2, readRDS() now returns cached GE GPS files as sf 
     objects rather than plain data frames. This caused type.convert() to fail on 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# naomi.utils 0.0.16
+* Remove `spud` dependency as package is deprecated 
+* Fix GE dataset parsing broken by R/sf upgrade
+  * After upgrading to R 4.5.2, readRDS() now returns cached GE GPS files as sf 
+    objects rather than plain data frames. This caused type.convert() to fail on 
+    the retained sfc geometry column.
+  * Fix adds st_drop_geometry() before as.data.frame() to remove the geometry 
+    column before processing, with the sf object reconstructed from LONGNUM/LATNUM 
+    as before.
+
 
 # naomi.utils 0.0.16
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-# naomi.utils 0.0.16
+# naomi.utils 0.0.17
+
 * Remove `spud` dependency as package is deprecated 
 * Fix GE dataset parsing broken by R/sf upgrade
   * After upgrading to R 4.5.2, readRDS() now returns cached GE GPS files as sf 
@@ -7,7 +8,6 @@
   * Fix adds st_drop_geometry() before as.data.frame() to remove the geometry 
     column before processing, with the sf object reconstructed from LONGNUM/LATNUM 
     as before.
-
 
 # naomi.utils 0.0.16
 

--- a/R/debug.R
+++ b/R/debug.R
@@ -46,8 +46,8 @@ upload_files <- function(sp_folder, files) {
 hintr_inputs_ready <- function(jobid, root = ".") {
   path <- file.path(normalizePath(root), jobid)
 
-  data <- readRDS(file.path(path, "data.rds"))$objects$data
-  options <- readRDS(file.path(path, "data.rds"))$objects$options
+  data <- readRDS(file.path(path, "data.rds"))$variables$data
+  options <- readRDS(file.path(path, "data.rds"))$variables$options
 
   data <- lapply(data, function(x){x$path <- file.path(path, "files", x$path); x})
 

--- a/R/utils_survey_dhs.R
+++ b/R/utils_survey_dhs.R
@@ -401,16 +401,18 @@ create_survey_clusters_dhs <- function(surveys, clear_rdhs_cache = FALSE) {
     ged$path <-  unlist(rdhs::get_datasets(ged, clear_cache = clear_rdhs_cache))
 
     ge <- lapply(ged$path, readRDS)
+    ge <- lapply(ge, sf::st_drop_geometry)
     ge <- lapply(ge, as.data.frame)
     ge <- Map(f = dplyr::mutate,
               ge,
-              survey_id = ged$survey_id,
-              SurveyYear = ged$SurveyYear,
-              SurveyType = ged$SurveyType,
+              survey_id   = ged$survey_id,
+              SurveyYear  = ged$SurveyYear,
+              SurveyType  = ged$SurveyType,
               CountryName = ged$CountryName)
     ge <- Map(replace, ge, lapply(ge, `==`, "NULL"), NA)
-    ge <- lapply(ge, type.convert)
-    ge <- dplyr::bind_rows(ge)
+    ge <- dplyr::bind_rows(ge)              # bind first so columns are consistent
+    ge <- type.convert(ge, as.is = TRUE)   # then convert — note as.is = TRUE avoids
+    # character columns becoming factors
     ge <- sf::st_as_sf(ge, coords = c("LONGNUM", "LATNUM"), remove = FALSE)
 
     ge <- dplyr::filter(ge, LONGNUM != 0)


### PR DESCRIPTION
* Remove `spud` dependency as package is deprecated 
* Update debug functions in line with updated data structure in fit object downloaded from `download_debug()`
* Fix GE dataset parsing broken by R/sf upgrade
  * After upgrading to R 4.5.2, readRDS() now returns cached GE GPS files as sf 
    objects rather than plain data frames. This caused type.convert() to fail on 
    the retained sfc geometry column.
  * Fix adds st_drop_geometry() before as.data.frame() to remove the geometry 
    column before processing, with the sf object reconstructed from LONGNUM/LATNUM 
    as before.